### PR TITLE
Comment out removeOlderResults for OH5 compatibility

### DIFF
--- a/src/main/java/no/seime/openhab/binding/panasoniccomfortcloud/internal/discovery/PanasonicComfortCloudDiscoveryService.java
+++ b/src/main/java/no/seime/openhab/binding/panasoniccomfortcloud/internal/discovery/PanasonicComfortCloudDiscoveryService.java
@@ -64,7 +64,8 @@ public class PanasonicComfortCloudDiscoveryService extends AbstractDiscoveryServ
     protected void startScan() {
         logger.debug("Start scan for Panasonic Comfort Cloud devices.");
         synchronized (this) {
-            removeOlderResults(getTimestampOfLastScan(), null, accountHandler.getThing().getUID());
+            // REMOVED FOR NOW, NOT COMPATIBLE WITH OH5. 
+            // removeOlderResults(getTimestampOfLastScan(), null, accountHandler.getThing().getUID());
             final ThingUID accountUID = accountHandler.getThing().getUID();
             accountHandler.doPoll(false);
 


### PR DESCRIPTION
Commented out the removeOlderResults method call due to compatibility issues with OH5.